### PR TITLE
Complete Rework & Fixes

### DIFF
--- a/GT.RText.Core/RT03.cs
+++ b/GT.RText.Core/RT03.cs
@@ -1,116 +1,94 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using GT.RText.Core.Structs;
+using System.Text;
+using System.Linq;
+
 using GT.Shared.Logging;
 using GT.Shared.Polyphony;
 
 namespace GT.RText.Core
 {
-    public class RT03 : IRText
+    /// <summary>
+    /// Gran Turismo 4/Tourist Trophy/PSP/GT5P Localization Strings
+    /// </summary>
+    public class RT03 : RTextBase
     {
-        private readonly ILogWriter _logWriter;
-        private readonly byte[] _data;
-        private RT03Header _header;
+        public static readonly string Magic = "RT03";
+        public const int HeaderSize = 0x10;
 
-        private List<IRTextCategory> _categories { get; set; }
+        private readonly ILogWriter _logWriter;
 
         public RT03(string filePath, ILogWriter logWriter = null)
         {
             if (!File.Exists(filePath))
                 throw new FileNotFoundException();
 
-            _data = File.ReadAllBytes(filePath);
+
             _logWriter = logWriter;
-
-            Read();
         }
 
-        public RT03(byte[] data, ILogWriter logWriter = null)
+        public RT03(ILogWriter logWriter = null)
         {
-            _data = data;
             _logWriter = logWriter;
-
-            Read();
         }
 
-        public List<IRTextCategory> GetCategories()
-        {
-            return _categories;
-        }
-
-        public void GetCategoryByIndex()
+        public void GetPageByIndex()
         {
             throw new NotImplementedException();
         }
 
-        public void GetStringByCategory(int categoryIndex)
+        public void GetStringByPage(int pageIndex)
         {
             throw new NotImplementedException();
         }
 
-        public void Save(string filePath)
-        {
-            File.WriteAllBytes(filePath, Write());
-        }
 
-        private void Read()
+        public override void Read(byte[] data)
         {
-            ReadHeader();
-            ReadCategories();
-        }
-
-        private void ReadHeader()
-        {
-            using (var ms = new MemoryStream(_data))
+            using (var ms = new MemoryStream(data))
             using (var reader = new EndianBinReader(ms, EndianType.LITTLE_ENDIAN))
             {
-                _header = new RT03Header(reader);
-            }
-        }
+                reader.BaseStream.Position = 0;
+                if (reader.ReadString(4) != Magic)
+                    throw new Exception("Invalid magic, doesn't match RT03.");
 
-        private void ReadCategories()
-        {
-            _categories = new List<IRTextCategory>();
-            for (int i = 0; i < _header.EntryCount; i++)
-            {
-                var category = new RT03Category(_data, i, _logWriter);
-                category.Read();
-                _categories.Add(category);
+                reader.ReadInt32(); // Relocation Ptr
+                reader.ReadUInt32(); // Empty - skipped by GT4
+                int entryCount = reader.ReadInt32();
+
+                for (int i = 0; i < entryCount; i++)
+                {
+                    ms.Position = HeaderSize + (i * 0x10);
+                    var page = new RT03Page(_logWriter);
+                    page.Read(reader);
+                    _pages.Add(page.Name, page);
+                }
             }
         }
 
         #region Saving
-        private byte[] Write()
+        public override void Save(string fileName)
         {
-            using (var ms = new MemoryStream())
-            using (var ms2 = new MemoryStream())
-            using (var ms3 = new MemoryStream())
-            using (var headerWriter = new EndianBinWriter(ms, EndianType.LITTLE_ENDIAN))
-            using (var categoryMetaWriter = new EndianBinWriter(ms2, EndianType.LITTLE_ENDIAN))
-            using (var entryWriter = new EndianBinWriter(ms3, EndianType.LITTLE_ENDIAN))
+            using (var ms = new FileStream(fileName, FileMode.Create))
+            using (var bs = new EndianBinWriter(ms, EndianType.LITTLE_ENDIAN))
             {
-                // Write the header
-                _header.EntryCount = (uint)_categories.Count;
-                _header.Save(headerWriter);
+                bs.Write(Encoding.ASCII.GetBytes(Magic));
+                bs.Write(0);
+                bs.Write(0);
+                bs.Write(_pages.Count);
 
-                // Write categories
-                foreach (var category in _categories)
+                int i = 0;
+                int baseDataPos = HeaderSize + (_pages.Count * 0x10);
+                foreach (var pagePair in _pages)
                 {
-                    // Write category title offset in the meta data
-                    categoryMetaWriter.Write((uint)(headerWriter.BaseStream.Length + (_categories.Count * 0x10) + entryWriter.BaseStream.Length));
-                    categoryMetaWriter.Write(category.Entries.Count);
-                    entryWriter.WriteNullTerminatedString(category.Name, 4);
-                    categoryMetaWriter.Write((int)(headerWriter.BaseStream.Length + (_categories.Count * 0x10) +  entryWriter.BaseStream.Length));
-                    categoryMetaWriter.Write(0x5E5E5E5E);
-
-                    category.Save((int)(headerWriter.BaseStream.Length + (_categories.Count * 0x10) + entryWriter.BaseStream.Length), entryWriter);
+                    int baseEntryOffset = (int)HeaderSize + (i * 0x10);
+                    pagePair.Value.Write(bs, baseEntryOffset, baseDataPos);
+                    baseDataPos = (int)ms.Position;
+                    i++;
                 }
 
-                headerWriter.Write(ms2.ToArray());
-                headerWriter.Write(ms3.ToArray());
-
-                return ms.ToArray();
+                
             }
         }
         #endregion

--- a/GT.RText.Core/RT03Page.cs
+++ b/GT.RText.Core/RT03Page.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using GT.Shared.Logging;
+using GT.Shared.Polyphony;
+
+namespace GT.RText.Core
+{
+    public class RT03Page : RTextPageBase
+    {
+        private readonly ILogWriter _logWriter;
+        public const int EntrySize = 0x08;
+
+        public RT03Page(ILogWriter logWriter = null)
+        {
+            _logWriter = logWriter;
+        }
+
+        public override void Read(EndianBinReader reader)
+        {
+            var pageNameOffset = reader.ReadUInt32();
+            var pairUnitCount = reader.ReadUInt32();
+            var pairUnitOffset = reader.ReadUInt32();
+
+            reader.BaseStream.Position = pageNameOffset;
+            Name = reader.ReadNullTerminatedString();
+
+            reader.BaseStream.Position += reader.BaseStream.Position % 0x10; // Padding with 0x5E
+
+            for (int i = 0; i < pairUnitCount; i++)
+            {
+                reader.BaseStream.Position = pairUnitOffset + (i * 0x08);
+                uint labelOffset = reader.ReadUInt32();
+                uint valueOffset = reader.ReadUInt32();
+
+                reader.BaseStream.Position = labelOffset;
+                string label = reader.ReadNullTerminatedString();
+
+                reader.BaseStream.Position = valueOffset;
+                string value = reader.ReadNullTerminatedString();
+
+                var pair = new RTextPairUnit(0, label, value);
+                PairUnits.Add(label, pair);
+            }
+        }
+
+        public override void Write(EndianBinWriter writer, int baseOffset, int baseDataOffset)
+        {
+            writer.BaseStream.Position = baseDataOffset;
+            int baseNameOffset = (int)writer.BaseStream.Position;
+            writer.WriteNullTerminatedString(Name, 0x04);
+            int pairUnitOffset = (int)writer.BaseStream.Position;
+
+            // Proceed to write the string tree, skip the entry map for now
+            writer.BaseStream.Position += EntrySize * PairUnits.Count;
+            int lastStringPos = (int)writer.BaseStream.Position;
+
+            // Write our strings
+            int j = 0;
+            foreach (var pair in PairUnits)
+            {
+                writer.BaseStream.Position = lastStringPos;
+
+                int labelOffset = (int)writer.BaseStream.Position;
+                writer.WriteNullTerminatedString(pair.Value.Label, 4);
+
+                int valueOffset = (int)writer.BaseStream.Position;
+                writer.WriteNullTerminatedString(pair.Value.Value, 4);
+
+                lastStringPos = (int)writer.BaseStream.Position;
+
+                // Write the offsets
+                writer.BaseStream.Position = pairUnitOffset + (j * RT03Page.EntrySize);
+                writer.Write(labelOffset);
+                writer.Write(valueOffset);
+
+                j++;
+            }
+
+            // Finish page toc entry
+            writer.BaseStream.Position = baseOffset;
+            writer.Write(baseNameOffset);
+            writer.Write(PairUnits.Count);
+            writer.Write(pairUnitOffset);
+            writer.Write(0x5E5E5E5E); // Padding
+
+            // Seek to the end of it
+            writer.BaseStream.Position = writer.BaseStream.Length;
+        }
+    }
+}

--- a/GT.RText.Core/RT04Page.cs
+++ b/GT.RText.Core/RT04Page.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using GT.Shared.Logging;
+using GT.Shared.Polyphony;
+
+namespace GT.RText.Core
+{
+    public class RT04Page : RTextPageBase
+    {
+        public const int EntrySize = 0x0C;
+
+        private readonly ILogWriter _logWriter;
+        public RT04Page(ILogWriter logWriter = null)
+        {
+            _logWriter = logWriter;
+        }
+
+        public override void Read(EndianBinReader reader)
+        {
+            var pageNameOffset = reader.ReadUInt32();
+            var pairUnitCount = reader.ReadUInt32();
+            var pairUnitOffset = reader.ReadUInt32();
+
+            reader.BaseStream.Position = pageNameOffset;
+            Name = reader.ReadNullTerminatedString();
+
+            reader.BaseStream.Position += reader.BaseStream.Position % 0x10; // Padding with 0x5E
+
+            for (int i = 0; i < pairUnitCount; i++)
+            {
+                reader.BaseStream.Position = pairUnitOffset + (i * EntrySize);
+                int id = reader.ReadInt32();
+                uint labelOffset = reader.ReadUInt32();
+                uint valueOffset = reader.ReadUInt32();
+
+                reader.BaseStream.Position = labelOffset;
+                string label = reader.ReadNullTerminatedString();
+
+                reader.BaseStream.Position = valueOffset;
+                string value = reader.ReadNullTerminatedString();
+
+                var pair = new RTextPairUnit(id, label, value);
+                PairUnits.Add(label, pair);
+            }
+        }
+
+        
+        public override void Write(EndianBinWriter writer, int baseOffset, int baseDataOffset)
+        {
+            writer.BaseStream.Position = baseDataOffset;
+            int baseNameOffset = (int)writer.BaseStream.Position;
+            writer.WriteNullTerminatedString(Name, 0x04);
+            int pairUnitOffset = (int)writer.BaseStream.Position;
+
+            // Proceed to write the string tree, skip the entry map for now
+            writer.BaseStream.Position += EntrySize * PairUnits.Count;
+            int lastStringPos = (int)writer.BaseStream.Position;
+
+            // Write our strings
+            int j = 0;
+            foreach (var pair in PairUnits)
+            {
+                writer.BaseStream.Position = lastStringPos;
+
+                int labelOffset = (int)writer.BaseStream.Position;
+                writer.WriteNullTerminatedString(pair.Value.Label, 4);
+
+                int valueOffset = (int)writer.BaseStream.Position;
+                writer.WriteNullTerminatedString(pair.Value.Value, 4);
+
+                lastStringPos = (int)writer.BaseStream.Position;
+
+                // Write the offsets
+                writer.BaseStream.Position = pairUnitOffset + (j * RT04Page.EntrySize);
+                writer.Write(pair.Value.ID);
+                writer.Write(labelOffset);
+                writer.Write(valueOffset);
+
+                j++;
+            }
+
+            // Finish page toc entry
+            writer.BaseStream.Position = baseOffset;
+            writer.Write(baseNameOffset);
+            writer.Write(PairUnits.Count);
+            writer.Write(pairUnitOffset);
+            writer.Write(0x5E5E5E5E); // Padding
+
+            // Seek to the end of it
+            writer.BaseStream.Position = writer.BaseStream.Length;
+        }
+    }
+}

--- a/GT.RText.Core/RT05.cs
+++ b/GT.RText.Core/RT05.cs
@@ -2,105 +2,89 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using GT.RText.Core.Structs;
 using GT.Shared.Logging;
 using GT.Shared.Polyphony;
 
 namespace GT.RText.Core
 {
-    public class RT05 : IRText
+    /// <summary>
+    /// Gran Turismo 6 Localization Strings (Encryption)
+    /// </summary>
+    public class RT05 : RTextBase
     {
-        private readonly ILogWriter _logWriter;
-        private readonly byte[] _data;
-        private RT05Header _header;
+        public static readonly string Magic = "RT05";
+        public const int HeaderSize = 0x20;
 
-        private List<IRTextCategory> _categories { get; set; }
+        private readonly ILogWriter _logWriter;
 
         public RT05(string filePath, ILogWriter logWriter = null)
         {
             if (!File.Exists(filePath))
                 throw new FileNotFoundException();
 
-            _data = File.ReadAllBytes(filePath);
+
             _logWriter = logWriter;
-
-            Read();
         }
 
-        public RT05(byte[] data, ILogWriter logWriter = null)
+        public RT05(ILogWriter logWriter = null)
         {
-            _data = data;
             _logWriter = logWriter;
-
-            Read();
         }
 
-        public List<IRTextCategory> GetCategories()
+        public void GetCategoryByIndex()
         {
-            return _categories;
+            throw new NotImplementedException();
         }
 
-        private void Read()
+        public void GetStringByCategory(int categoryIndex)
         {
-            ReadHeader();
-            ReadCategories();
+            throw new NotImplementedException();
         }
 
-        private void ReadHeader()
+        public override void Read(byte[] data)
         {
-            using (var ms = new MemoryStream(_data))
-            using (var reader = new EndianBinReader(ms))
+            using (var ms = new MemoryStream(data))
+            using (var reader = new EndianBinReader(ms, EndianType.BIG_ENDIAN))
             {
-                _header = new RT05Header(reader);
-            }
-        }
+                reader.BaseStream.Position = 0;
+                if (reader.ReadString(4) != Magic)
+                    throw new Exception($"Invalid magic, doesn't match {Magic}.");
 
-        private void ReadCategories()
-        {
-            _categories = new List<IRTextCategory>();
-            for (int i = 0; i < _header.EntryCount; i++)
-            {
-                var category = new RT05Category(_header, _data, i, _logWriter);
-                category.Read();
-                _categories.Add(category);
-            }
-        }
+                int entryCount = reader.ReadInt32();
 
-        public void Save(string filePath)
-        {
-            File.WriteAllBytes(filePath, Write());
-        }
+                // Relocation ptr is at 0x10
 
-        private byte[] Write()
-        {
-            using (var ms = new MemoryStream())
-            using (var ms2 = new MemoryStream())
-            using (var ms3 = new MemoryStream())
-            using (var headerWriter = new EndianBinWriter(ms))
-            using (var categoryMetaWriter = new EndianBinWriter(ms2))
-            using (var entryWriter = new EndianBinWriter(ms3))
-            {
-                // Write the header
-                _header.EntryCount = (uint)_categories.Count;
-                _header.Save(headerWriter);
+                // Data starts at 0x20
 
-                // Write categories
-                foreach (var category in _categories)
+                for (int i = 0; i < entryCount; i++)
                 {
-                    // Write category title offset in the meta data
-                    categoryMetaWriter.Write((uint)(headerWriter.BaseStream.Length + (_categories.Count * 0x10) + entryWriter.BaseStream.Length));
-                    categoryMetaWriter.Write(category.Entries.Count);
-                    categoryMetaWriter.Write(0x00000000);
-                    entryWriter.WriteNullTerminatedString(category.Name, 4);
-                    categoryMetaWriter.Write((int)(headerWriter.BaseStream.Length + (_categories.Count * 0x10) + entryWriter.BaseStream.Length));
-
-                    category.Save((int)(headerWriter.BaseStream.Length + (_categories.Count * 0x10) + entryWriter.BaseStream.Length), entryWriter);
+                    ms.Position = HeaderSize + (i * 0x10);
+                    var page = new RT05Page(_logWriter);
+                    page.Read(reader);
+                    _pages.Add(page.Name, page);
                 }
+            }
+        }
 
-                headerWriter.Write(ms2.ToArray());
-                headerWriter.Write(ms3.ToArray());
+        public override void Save(string fileName)
+        {
+            using (var ms = new FileStream(fileName, FileMode.Create))
+            using (var bs = new EndianBinWriter(ms, EndianType.BIG_ENDIAN))
+            {
+                bs.Write(Encoding.ASCII.GetBytes(Magic));
+                bs.Write(_pages.Count);
+                bs.Write((byte)1); // "Obfuscated", we don't know, eboot doesn't read it
+                bs.BaseStream.Position = HeaderSize;
 
-                return ms.ToArray();
+                int i = 0;
+                int baseDataPos = HeaderSize + (_pages.Count * 0x10);
+                foreach (var pagePair in _pages)
+                {
+                    int baseEntryOffset = (int)HeaderSize + (i * 0x10);
+                    pagePair.Value.Write(bs, baseEntryOffset, baseDataPos);
+                    baseDataPos = (int)ms.Position;
+                    i++;
+                }
             }
         }
     }

--- a/GT.RText.Core/RT05Page.cs
+++ b/GT.RText.Core/RT05Page.cs
@@ -1,0 +1,142 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using GT.Shared;
+using GT.Shared.Crypt;
+using GT.Shared.Logging;
+
+namespace GT.RText.Core
+{
+    public class RT05Page : RTextPageBase
+    {
+        private readonly ILogWriter _logWriter;
+        public const int EntrySize = 0x10;
+
+        public RT05Page(ILogWriter logWriter = null)
+        {
+            _logWriter = logWriter;
+        }
+
+        public override void Read(EndianBinReader reader)
+        {
+            var pageNameOffset = reader.ReadUInt32();
+            var pairUnitCount = reader.ReadUInt32();
+            reader.ReadUInt32(); // Unk
+            var pairUnitOffset = reader.ReadUInt32();
+
+            reader.BaseStream.Position = (int)pageNameOffset;
+            Name = reader.ReadNullTerminatedString();
+
+            for (int i = 0; i < pairUnitCount; i++)
+            {
+                reader.BaseStream.Position = pairUnitOffset + (i * EntrySize);
+                int id = reader.ReadInt32();
+
+                ushort labelLen = reader.ReadUInt16();
+                ushort valueLen = reader.ReadUInt16();
+
+                uint labelOffset = reader.ReadUInt32();
+                uint valueOffset = reader.ReadUInt32();
+
+                reader.BaseStream.Position = labelOffset;
+                string label = ReadString(reader, labelLen);
+
+                reader.BaseStream.Position = valueOffset;
+                string value = ReadString(reader, valueLen);
+
+                var pair = new RTextPairUnit(id, label, value);
+                PairUnits.Add(label, pair);
+            }
+        }
+
+        public override void Write(EndianBinWriter writer, int baseOffset, int baseDataOffset)
+        {
+            writer.BaseStream.Position = baseDataOffset;
+            int baseNameOffset = (int)writer.BaseStream.Position;
+            writer.WriteNullTerminatedString(Name, 0x04);
+            int pairUnitOffset = (int)writer.BaseStream.Position;
+
+            // Proceed to write the string tree, skip the entry map for now
+            writer.BaseStream.Position += EntrySize * PairUnits.Count;
+            int lastStringPos = (int)writer.BaseStream.Position;
+
+            // Write our strings
+            int j = 0;
+            foreach (var pair in PairUnits)
+            {
+                writer.BaseStream.Position = lastStringPos;
+
+                int labelOffset = (int)writer.BaseStream.Position;
+                var encLabel = Encrypt(Encoding.UTF8.GetBytes(pair.Value.Label), Constants.KEY.AlignString(0x20));
+                writer.WriteAligned(encLabel, 4, nullTerminate: true);
+
+                int valueOffset = (int)writer.BaseStream.Position;
+                var encValue = Encrypt(Encoding.UTF8.GetBytes(pair.Value.Value), Constants.KEY.AlignString(0x20));
+                writer.WriteAligned(encValue, 4, nullTerminate: true);
+
+                lastStringPos = (int)writer.BaseStream.Position;
+
+                // Write the offsets
+                writer.BaseStream.Position = pairUnitOffset + (j * EntrySize);
+                writer.Write(pair.Value.ID);
+                writer.Write((ushort)(pair.Value.Label.Length + 1));
+                writer.Write((ushort)(pair.Value.Value.Length + 1));
+                writer.Write(labelOffset);
+                writer.Write(valueOffset);
+
+                j++;
+            }
+
+            // Finish page toc entry
+            writer.BaseStream.Position = baseOffset;
+            writer.Write(baseNameOffset);
+            writer.Write(PairUnits.Count);
+            writer.Write(0); // Unk
+            writer.Write(pairUnitOffset);
+
+            // Seek to the end of it
+            writer.BaseStream.Position = writer.BaseStream.Length;
+        }
+
+        private string ReadString(EndianBinReader reader, ushort length)
+        {
+            var buffer = reader.ReadBytes(length - 1);
+
+            /* Haven't seen any evidence in the gt6 eboot upon getting a string that this corresponds to a rtext being encrypted
+            if (_header.Obfuscated == 1 && buffer.Length > 0)
+                buffer = Decrypt(buffer, Constants.KEY.AlignString(0x20)); */
+            buffer = Decrypt(buffer, Constants.KEY.AlignString(0x20));
+            return Encoding.UTF8.GetString(buffer);
+        }
+
+        static byte[] Decrypt(byte[] encrypted, string key)
+        {
+            using (SymmetricAlgorithm salsa20 = new Salsa20())
+            {
+                var dataKey = new byte[8];
+                var keyBytes = Encoding.UTF8.GetBytes(key);
+                byte[] decrypted = new byte[encrypted.Length];
+                using (var decrypt = salsa20.CreateDecryptor(keyBytes, dataKey))
+                    decrypt.TransformBlock(encrypted, 0, encrypted.Length, decrypted, 0);
+
+                return decrypted;
+            }
+        }
+
+        static byte[] Encrypt(byte[] input, string key)
+        {
+            using (SymmetricAlgorithm salsa20 = new Salsa20())
+            {
+                var dataKey = new byte[8];
+                var keyBytes = Encoding.UTF8.GetBytes(key);
+
+                byte[] encrypted = new byte[input.Length];
+                using (var encrypt = salsa20.CreateEncryptor(keyBytes, dataKey))
+                    encrypt.TransformBlock(input, 0, input.Length, encrypted, 0);
+
+                return encrypted;
+            }
+        }
+    }
+}

--- a/GT.RText.Core/RTextBase.cs
+++ b/GT.RText.Core/RTextBase.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GT.Shared;
+namespace GT.RText.Core
+{
+    public abstract class RTextBase
+    {
+        protected SortedDictionary<string, RTextPageBase> _pages { get; set; } 
+            = new SortedDictionary<string, RTextPageBase>(AlphaNumStringComparer.Default);
+
+        public SortedDictionary<string, RTextPageBase> GetPages()
+        {
+            return _pages;
+        }
+
+        public abstract void Read(byte[] buffer);
+
+        /* Note & possible minor TODO - use optimized string table:
+         * While we are saving strings ordered, we still aren't storing the strings optimally
+         * As in - different entry offsets may point to the same string offsets to save on size
+         * Most specifically noticeable in car description rt2's
+         */
+        public abstract void Save(string filePath);
+    }
+}

--- a/GT.RText.Core/RTextPageBase.cs
+++ b/GT.RText.Core/RTextPageBase.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+
+using GT.Shared;
+
+namespace GT.RText.Core
+{
+    public abstract class RTextPageBase
+    {
+        public string Name { get; set; }
+
+        // We need to have them ordered, game uses binary searching
+        public SortedDictionary<string, RTextPairUnit> PairUnits { get; set; }
+            = new SortedDictionary<string, RTextPairUnit>(AlphaNumStringComparer.Default);
+
+        public void EditRow(int id, string label, string data)
+        {
+            if (!PairUnits.ContainsKey(label))
+                return;
+
+            PairUnits[label] = new RTextPairUnit(id, label, data);
+        }
+
+        public int AddRow(int id, string label, string data)
+        {
+            var index = PairUnits.Count;
+            PairUnits.Add(label, new RTextPairUnit(id, label, data));
+            return index;
+        }
+
+        public void DeleteRow(string label)
+            => PairUnits.Remove(label);
+
+        public abstract void Read(EndianBinReader reader);
+        public abstract void Write(EndianBinWriter writer, int baseOffset, int baseDataOffset);
+    }
+}

--- a/GT.RText.Core/RTextPairUnit.cs
+++ b/GT.RText.Core/RTextPairUnit.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GT.RText.Core
+{
+    public class RTextPairUnit
+    {
+        public int ID { get; set; }
+        public string Label { get; set; }
+        public string Value { get; set; }
+
+        public RTextPairUnit(int id, string label, string value)
+        {
+            ID = id;
+            Label = label;
+            Value = value;
+        }
+    }
+}

--- a/GT.RText.Core/RTextParser.cs
+++ b/GT.RText.Core/RTextParser.cs
@@ -11,9 +11,8 @@ namespace GT.RText.Core
     public class RTextParser
     {
         private readonly ILogWriter _logWriter;
-        private readonly byte[] _data;
 
-        public IRText RText { get; set; }
+        public RTextBase RText { get; set; }
 
         public string LocaleCode { get; set; }
 
@@ -34,58 +33,46 @@ namespace GT.RText.Core
             { "JP", "Japanese" },
             { "KR", "Korean" },
             { "MS", "Spanish (Mexican)" },
-            { "NO", "NO" }, // TODO
+            { "NO", "Norwegian" },
             { "NL", "Dutch" },
             { "PL", "Polish" },
             { "PT", "Portuguese" },
             { "RU", "Russian" },
-            { "SE", "SE" }, // TODO
+            { "SE", "Swedish" },
             { "TR", "Turkish" },
             { "TW", "Chinese (Taiwan)" },
             { "US", "American" }
         };
 
-        public RTextParser(string filePath, ILogWriter logWriter = null)
+        public RTextParser(ILogWriter logWriter = null)
         {
-            if (!File.Exists(filePath))
-                throw new FileNotFoundException();
-
-            _data = File.ReadAllBytes(filePath);
             _logWriter = logWriter;
-
-            Read();
         }
 
-        public RTextParser(byte[] data, ILogWriter logWriter = null)
+        public void Read(byte[] data)
         {
-            _data = data;
-            _logWriter = logWriter;
-
-            Read();
-        }
-
-        private void Read()
-        {
-            using (var ms = new MemoryStream(_data))
+            using (var ms = new MemoryStream(data))
             using (var reader = new EndianBinReader(ms))
             {
                 switch (reader.ReadUInt32())
                 {
                     case Constants.RT03_MAGIC:
-                        RText = new RT03(_data, _logWriter);
+                        RText = new RT03(_logWriter);
                         break;
                     case Constants.RT04_MAGIC:
-                        RText = new RT04(_data, _logWriter);
+                        RText = new RT04(_logWriter);
                         break;
                     case Constants.RT05_MAGIC:
-                        RText = new RT05(_data, _logWriter);
+                        RText = new RT05( _logWriter);
                         break;
                     case Constants._50TR_MAGIC:
-                        RText = new _50TR(_data, _logWriter);
+                        RText = new _50TR(_logWriter);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException("Unknown header magic.");
                 }
+
+                RText.Read(data);
             }
         }
     }

--- a/GT.RText.Core/_50TRPage.cs
+++ b/GT.RText.Core/_50TRPage.cs
@@ -1,0 +1,143 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+using GT.Shared;
+using GT.Shared.Crypt;
+using GT.Shared.Logging;
+
+namespace GT.RText.Core
+{
+    public class _50TRPage : RTextPageBase
+    {
+        private readonly ILogWriter _logWriter;
+        public const int EntrySize = 0x10;
+
+        public _50TRPage(ILogWriter logWriter = null)
+        {
+            _logWriter = logWriter;
+        }
+
+        public override void Read(EndianBinReader reader)
+        {
+            var pageNameOffset = reader.ReadUInt32();
+            var pairUnitCount = reader.ReadUInt32();
+            reader.ReadUInt32(); // Unk
+            var pairUnitOffset = reader.ReadUInt32();
+
+            reader.BaseStream.Position = (int)pageNameOffset;
+            Name = reader.ReadNullTerminatedString();
+
+            for (int i = 0; i < pairUnitCount; i++)
+            {
+                reader.BaseStream.Position = pairUnitOffset + (i * EntrySize);
+                int id = reader.ReadInt32();
+
+                ushort labelLen = reader.ReadUInt16();
+                ushort valueLen = reader.ReadUInt16();
+
+                uint labelOffset = reader.ReadUInt32();
+                uint valueOffset = reader.ReadUInt32();
+
+                reader.BaseStream.Position = labelOffset;
+                string label = ReadString(reader, labelLen);
+
+                reader.BaseStream.Position = valueOffset;
+                string value = ReadString(reader, valueLen);
+
+                var pair = new RTextPairUnit(id, label, value);
+                PairUnits.Add(label, pair);
+            }
+        }
+
+        public override void Write(EndianBinWriter writer, int baseOffset, int baseDataOffset)
+        {
+            writer.BaseStream.Position = baseDataOffset;
+            int baseNameOffset = (int)writer.BaseStream.Position;
+            writer.WriteNullTerminatedString(Name, 0x04);
+            int pairUnitOffset = (int)writer.BaseStream.Position;
+
+            // Proceed to write the string tree, skip the entry map for now
+            writer.BaseStream.Position += EntrySize * PairUnits.Count;
+            int lastStringPos = (int)writer.BaseStream.Position;
+
+            // Write our strings
+            int j = 0;
+            foreach (var pair in PairUnits)
+            {
+                writer.BaseStream.Position = lastStringPos;
+
+                int labelOffset = (int)writer.BaseStream.Position;
+                var encLabel = Encrypt(Encoding.UTF8.GetBytes(pair.Value.Label), Constants.KEY.AlignString(0x20));
+                writer.WriteAligned(encLabel, 4, nullTerminate: true);
+
+                int valueOffset = (int)writer.BaseStream.Position;
+                var encValue = Encrypt(Encoding.UTF8.GetBytes(pair.Value.Value), Constants.KEY.AlignString(0x20));
+                writer.WriteAligned(encValue, 4, nullTerminate: true);
+
+                lastStringPos = (int)writer.BaseStream.Position;
+
+                // Write the offsets
+                writer.BaseStream.Position = pairUnitOffset + (j * EntrySize);
+                writer.Write(pair.Value.ID);
+                writer.Write((ushort)(pair.Value.Label.Length + 1));
+                writer.Write((ushort)(pair.Value.Value.Length + 1));
+                writer.Write(labelOffset);
+                writer.Write(valueOffset);
+
+                j++;
+            }
+
+            // Finish page toc entry
+            writer.BaseStream.Position = baseOffset;
+            writer.Write(baseNameOffset);
+            writer.Write(PairUnits.Count);
+            writer.Write(0); // Unk
+            writer.Write(pairUnitOffset);
+
+            // Seek to the end of it
+            writer.BaseStream.Position = writer.BaseStream.Length;
+        }
+
+        private string ReadString(EndianBinReader reader, ushort length)
+        {
+            var buffer = reader.ReadBytes(length - 1);
+
+            /* Haven't seen any evidence in the gt6 eboot upon getting a string that this corresponds to a rtext being encrypted
+            if (_header.Obfuscated == 1 && buffer.Length > 0)
+                buffer = Decrypt(buffer, Constants.KEY.AlignString(0x20)); */
+            buffer = Decrypt(buffer, Constants.KEY.AlignString(0x20));
+            return Encoding.UTF8.GetString(buffer);
+        }
+
+        static byte[] Decrypt(byte[] encrypted, string key)
+        {
+            using (SymmetricAlgorithm salsa20 = new Salsa20())
+            {
+                var dataKey = new byte[8];
+                var keyBytes = Encoding.UTF8.GetBytes(key);
+                byte[] decrypted = new byte[encrypted.Length];
+                using (var decrypt = salsa20.CreateDecryptor(keyBytes, dataKey))
+                    decrypt.TransformBlock(encrypted, 0, encrypted.Length, decrypted, 0);
+
+                return decrypted;
+            }
+        }
+
+        static byte[] Encrypt(byte[] input, string key)
+        {
+            using (SymmetricAlgorithm salsa20 = new Salsa20())
+            {
+                var dataKey = new byte[8];
+                var keyBytes = Encoding.UTF8.GetBytes(key);
+
+                byte[] encrypted = new byte[input.Length];
+                using (var encrypt = salsa20.CreateEncryptor(keyBytes, dataKey))
+                    encrypt.TransformBlock(input, 0, input.Length, encrypted, 0);
+
+                return encrypted;
+            }
+        }
+    }
+}

--- a/GT.RText/Main.Designer.cs
+++ b/GT.RText/Main.Designer.cs
@@ -42,7 +42,7 @@
             this.toolStripStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.tabControlLocalFiles = new System.Windows.Forms.TabControl();
             this.listViewEntries = new System.Windows.Forms.ListView();
-            this.listViewCategories = new System.Windows.Forms.ListView();
+            this.listViewPages = new System.Windows.Forms.ListView();
             this.menuStrip.SuspendLayout();
             this.contextMenuStrip.SuspendLayout();
             this.statusStrip.SuspendLayout();
@@ -193,16 +193,16 @@
             // 
             // listViewCategories
             // 
-            this.listViewCategories.Dock = System.Windows.Forms.DockStyle.Left;
-            this.listViewCategories.HideSelection = false;
-            this.listViewCategories.Location = new System.Drawing.Point(0, 46);
-            this.listViewCategories.MultiSelect = false;
-            this.listViewCategories.Name = "listViewCategories";
-            this.listViewCategories.Size = new System.Drawing.Size(293, 382);
-            this.listViewCategories.TabIndex = 1;
-            this.listViewCategories.UseCompatibleStateImageBehavior = false;
-            this.listViewCategories.View = System.Windows.Forms.View.Details;
-            this.listViewCategories.SelectedIndexChanged += new System.EventHandler(this.listViewCategories_SelectedIndexChanged);
+            this.listViewPages.Dock = System.Windows.Forms.DockStyle.Left;
+            this.listViewPages.HideSelection = false;
+            this.listViewPages.Location = new System.Drawing.Point(0, 46);
+            this.listViewPages.MultiSelect = false;
+            this.listViewPages.Name = "listViewCategories";
+            this.listViewPages.Size = new System.Drawing.Size(293, 382);
+            this.listViewPages.TabIndex = 1;
+            this.listViewPages.UseCompatibleStateImageBehavior = false;
+            this.listViewPages.View = System.Windows.Forms.View.Details;
+            this.listViewPages.SelectedIndexChanged += new System.EventHandler(this.listViewCategories_SelectedIndexChanged);
             // 
             // Main
             // 
@@ -210,7 +210,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1228, 450);
             this.Controls.Add(this.listViewEntries);
-            this.Controls.Add(this.listViewCategories);
+            this.Controls.Add(this.listViewPages);
             this.Controls.Add(this.tabControlLocalFiles);
             this.Controls.Add(this.statusStrip);
             this.Controls.Add(this.menuStrip);
@@ -245,7 +245,7 @@
         private System.Windows.Forms.ToolStripMenuItem removeToolStripMenuItem;
         private System.Windows.Forms.TabControl tabControlLocalFiles;
         private System.Windows.Forms.ListView listViewEntries;
-        private System.Windows.Forms.ListView listViewCategories;
+        private System.Windows.Forms.ListView listViewPages;
         private System.Windows.Forms.ToolStripMenuItem openFolderToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;

--- a/GT.RText/Main.cs
+++ b/GT.RText/Main.cs
@@ -307,6 +307,12 @@ namespace GT.RText
                 var rowEditor = new RowEditor(CurrentRText.RText is RT03, _isUiFolderProject);
                 if (rowEditor.ShowDialog() == DialogResult.OK)
                 {
+                    if (page.PairUnits.ContainsKey(rowEditor.Label))
+                    {
+                        MessageBox.Show("This label already exists in this category.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+
                     if (_isUiFolderProject && rowEditor.ApplyToAllLocales)
                     {
                         foreach (var rt in _rTexts)

--- a/GT.RText/RowEditor.Designer.cs
+++ b/GT.RText/RowEditor.Designer.cs
@@ -71,7 +71,7 @@
             this.label_label.Name = "label_label";
             this.label_label.Size = new System.Drawing.Size(537, 23);
             this.label_label.TabIndex = 2;
-            this.label_label.Text = "Label";
+            this.label_label.Text = "Label (Must be Unique)";
             this.label_label.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // textBox_label

--- a/GT.Shared/AlphaNumStringComparer.cs
+++ b/GT.Shared/AlphaNumStringComparer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GT.Shared
+{
+    public class AlphaNumStringComparer : IComparer<string>
+    {
+        private static readonly AlphaNumStringComparer _default = new AlphaNumStringComparer();
+        public static AlphaNumStringComparer Default => _default;
+
+        public int Compare(string value1, string value2)
+        {
+            string v1 = value1;
+            string v2 = value2;
+
+            int min = v1.Length > v2.Length ? v2.Length : v1.Length;
+            for (int i = 0; i < min; i++)
+            {
+                if (v1[i] < v2[i])
+                    return -1;
+                else if (v1[i] > v2[i])
+                    return 1;
+            }
+            if (v1.Length < v2.Length)
+                return -1;
+            else if (v1.Length > v2.Length)
+                return 1;
+
+            return 0;
+        }
+    }
+}

--- a/GT.Shared/ByteBufferComparer.cs
+++ b/GT.Shared/ByteBufferComparer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GT.Shared
+{
+    public class ByteBufferComparer : IComparer<byte[]>
+    {
+        private static readonly ByteBufferComparer _default = new ByteBufferComparer();
+        public static ByteBufferComparer Default => _default;
+
+        public int Compare(byte[] value1, byte[] value2)
+        {
+            byte[] v1 = value1;
+            byte[] v2 = value2;
+
+            if (v1.Length < v2.Length)
+                return -1;
+            else if (v1.Length > v2.Length)
+                return 1;
+
+            int min = v1.Length > v2.Length ? v2.Length : v1.Length;
+            for (int i = 0; i < min; i++)
+            {
+                if (v1[i] < v2[i])
+                    return -1;
+                else if (v1[i] > v2[i])
+                    return 1;
+            }
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Reworked & Refactored the tool based on reverse engineering of the debug binary.

* Fixed a critical structure flaw; strings were never ordered while the games uses binary searching. For instance, non ordered rows would lead to GT5 not displaying event folder names & descriptions at all, GT6 would fail to display added car descriptions.
   - RT03/RT04 - Regular alphanumeric sorting
   - RT05/50TR - String Length then encrypted string buffer comparison (input would first be encrypted)
* `Category` -> `Page`
* Saving is more efficient (no duplicate streams created)
* Added a check when adding rows with labels already existing.