### PR TITLE
More robust CSV importing/exporting

### DIFF
--- a/GT.RText/Main.Designer.cs
+++ b/GT.RText/Main.Designer.cs
@@ -34,6 +34,7 @@
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.addEditFromCSVFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportCSVToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.addToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -53,12 +54,13 @@
             // 
             // menuStrip
             // 
+            this.menuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.editToolStripMenuItem1});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Size = new System.Drawing.Size(1228, 24);
+            this.menuStrip.Size = new System.Drawing.Size(1637, 28);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStrip1";
             // 
@@ -72,89 +74,98 @@
             this.toolStripSeparator2,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
             this.openToolStripMenuItem.Text = "Open File...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
             // openFolderToolStripMenuItem
             // 
             this.openFolderToolStripMenuItem.Name = "openFolderToolStripMenuItem";
-            this.openFolderToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
+            this.openFolderToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
             this.openFolderToolStripMenuItem.Text = "Open UI Folder..";
             this.openFolderToolStripMenuItem.Click += new System.EventHandler(this.openFolderToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(156, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(195, 6);
             // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(156, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(195, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
             // editToolStripMenuItem1
             // 
             this.editToolStripMenuItem1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.addEditFromCSVFileToolStripMenuItem});
+            this.addEditFromCSVFileToolStripMenuItem,
+            this.exportCSVToolStripMenuItem});
             this.editToolStripMenuItem1.Name = "editToolStripMenuItem1";
-            this.editToolStripMenuItem1.Size = new System.Drawing.Size(39, 20);
+            this.editToolStripMenuItem1.Size = new System.Drawing.Size(49, 24);
             this.editToolStripMenuItem1.Text = "Edit";
             // 
             // addEditFromCSVFileToolStripMenuItem
             // 
             this.addEditFromCSVFileToolStripMenuItem.Name = "addEditFromCSVFileToolStripMenuItem";
-            this.addEditFromCSVFileToolStripMenuItem.Size = new System.Drawing.Size(353, 22);
+            this.addEditFromCSVFileToolStripMenuItem.Size = new System.Drawing.Size(442, 26);
             this.addEditFromCSVFileToolStripMenuItem.Text = "Add/Edit Current Category from CSV File (Key, Value)";
             this.addEditFromCSVFileToolStripMenuItem.Click += new System.EventHandler(this.addEditFromCSVFileToolStripMenuItem_Click);
             // 
+            // exportCSVToolStripMenuItem
+            // 
+            this.exportCSVToolStripMenuItem.Name = "exportCSVToolStripMenuItem";
+            this.exportCSVToolStripMenuItem.Size = new System.Drawing.Size(442, 26);
+            this.exportCSVToolStripMenuItem.Text = "Export Current Category to CSV...";
+            this.exportCSVToolStripMenuItem.Click += new System.EventHandler(this.exportCSVToolStripMenuItem_Click);
+            // 
             // contextMenuStrip
             // 
+            this.contextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.editToolStripMenuItem,
             this.addToolStripMenuItem,
             this.removeToolStripMenuItem});
             this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(118, 70);
+            this.contextMenuStrip.Size = new System.Drawing.Size(133, 76);
             // 
             // editToolStripMenuItem
             // 
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(132, 24);
             this.editToolStripMenuItem.Text = "Edit";
             this.editToolStripMenuItem.Click += new System.EventHandler(this.editToolStripMenuItem_Click);
             // 
             // addToolStripMenuItem
             // 
             this.addToolStripMenuItem.Name = "addToolStripMenuItem";
-            this.addToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.addToolStripMenuItem.Size = new System.Drawing.Size(132, 24);
             this.addToolStripMenuItem.Text = "Add";
             this.addToolStripMenuItem.Click += new System.EventHandler(this.addToolStripMenuItem_Click);
             // 
             // removeToolStripMenuItem
             // 
             this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
-            this.removeToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.removeToolStripMenuItem.Size = new System.Drawing.Size(132, 24);
             this.removeToolStripMenuItem.Text = "Remove";
             this.removeToolStripMenuItem.Click += new System.EventHandler(this.removeToolStripMenuItem_Click);
             // 
@@ -166,30 +177,34 @@
             // 
             this.saveFileDialog.DefaultExt = "rt2";
             this.saveFileDialog.Filter = "RText files|*.rt2";
+            this.saveFileDialog.FileOk += new System.ComponentModel.CancelEventHandler(this.saveFileDialog_FileOk);
             // 
             // statusStrip
             // 
+            this.statusStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel});
-            this.statusStrip.Location = new System.Drawing.Point(0, 428);
+            this.statusStrip.Location = new System.Drawing.Point(0, 528);
             this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(1228, 22);
+            this.statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 19, 0);
+            this.statusStrip.Size = new System.Drawing.Size(1637, 26);
             this.statusStrip.TabIndex = 4;
             this.statusStrip.Text = "statusStrip1";
             // 
             // toolStripStatusLabel
             // 
             this.toolStripStatusLabel.Name = "toolStripStatusLabel";
-            this.toolStripStatusLabel.Size = new System.Drawing.Size(35, 17);
+            this.toolStripStatusLabel.Size = new System.Drawing.Size(43, 20);
             this.toolStripStatusLabel.Text = "Idle...";
             // 
             // tabControlLocalFiles
             // 
             this.tabControlLocalFiles.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tabControlLocalFiles.Location = new System.Drawing.Point(0, 24);
+            this.tabControlLocalFiles.Location = new System.Drawing.Point(0, 28);
+            this.tabControlLocalFiles.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tabControlLocalFiles.Name = "tabControlLocalFiles";
             this.tabControlLocalFiles.SelectedIndex = 0;
-            this.tabControlLocalFiles.Size = new System.Drawing.Size(1228, 22);
+            this.tabControlLocalFiles.Size = new System.Drawing.Size(1637, 27);
             this.tabControlLocalFiles.TabIndex = 5;
             this.tabControlLocalFiles.SelectedIndexChanged += new System.EventHandler(this.tabControlLocalFiles_SelectedIndexChanged);
             // 
@@ -199,10 +214,11 @@
             this.listViewEntries.Dock = System.Windows.Forms.DockStyle.Fill;
             this.listViewEntries.FullRowSelect = true;
             this.listViewEntries.HideSelection = false;
-            this.listViewEntries.Location = new System.Drawing.Point(293, 46);
+            this.listViewEntries.Location = new System.Drawing.Point(389, 55);
+            this.listViewEntries.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.listViewEntries.MultiSelect = false;
             this.listViewEntries.Name = "listViewEntries";
-            this.listViewEntries.Size = new System.Drawing.Size(935, 382);
+            this.listViewEntries.Size = new System.Drawing.Size(1248, 473);
             this.listViewEntries.TabIndex = 3;
             this.listViewEntries.UseCompatibleStateImageBehavior = false;
             this.listViewEntries.View = System.Windows.Forms.View.Details;
@@ -214,10 +230,11 @@
             // 
             this.listViewPages.Dock = System.Windows.Forms.DockStyle.Left;
             this.listViewPages.HideSelection = false;
-            this.listViewPages.Location = new System.Drawing.Point(0, 46);
+            this.listViewPages.Location = new System.Drawing.Point(0, 55);
+            this.listViewPages.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.listViewPages.MultiSelect = false;
             this.listViewPages.Name = "listViewPages";
-            this.listViewPages.Size = new System.Drawing.Size(293, 382);
+            this.listViewPages.Size = new System.Drawing.Size(389, 473);
             this.listViewPages.TabIndex = 1;
             this.listViewPages.UseCompatibleStateImageBehavior = false;
             this.listViewPages.View = System.Windows.Forms.View.Details;
@@ -229,15 +246,16 @@
             // 
             // Main
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1228, 450);
+            this.ClientSize = new System.Drawing.Size(1637, 554);
             this.Controls.Add(this.listViewEntries);
             this.Controls.Add(this.listViewPages);
             this.Controls.Add(this.tabControlLocalFiles);
             this.Controls.Add(this.statusStrip);
             this.Controls.Add(this.menuStrip);
             this.MainMenuStrip = this.menuStrip;
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "Main";
             this.Text = "RT2 Editor by xfileFIN";
             this.SizeChanged += new System.EventHandler(this.Main_SizeChanged);
@@ -275,6 +293,7 @@
         private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem addEditFromCSVFileToolStripMenuItem;
         private System.Windows.Forms.OpenFileDialog csvOpenFileDialog;
+        private System.Windows.Forms.ToolStripMenuItem exportCSVToolStripMenuItem;
     }
 }
 


### PR DESCRIPTION
Adds the option to export the current category as a CSV. Also reworks the import feature to be more robust and to handle this format of CSV.

<img width="1528" height="596" alt="image" src="https://github.com/user-attachments/assets/a7556eb8-86d7-4f56-b6fe-f8b825de53d2" />

Allows for quicker modifications of many records at once.

Before modification:
<img width="2426" height="940" alt="image" src="https://github.com/user-attachments/assets/5274853d-275b-4139-b435-5f1be6228123" />

Export:
<img width="1262" height="711" alt="image" src="https://github.com/user-attachments/assets/a5e54003-cd08-4ea1-993a-8f6fadf9f297" />

The resulting CSV:
<img width="995" height="383" alt="image" src="https://github.com/user-attachments/assets/329ccb8e-8862-4298-9c58-428f64e29cf6" />

Import:
<img width="1262" height="711" alt="image" src="https://github.com/user-attachments/assets/899205da-5e20-4f5d-9dc3-da6f51a4d4f6" />

After modification:
<img width="2445" height="952" alt="image" src="https://github.com/user-attachments/assets/9d97c187-5b21-496a-b1c9-96712368627b" />
